### PR TITLE
Add support for force connect and option for ignoring errors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,9 @@ Here are the steps to get the TRMNL app working on your Kobo (show hidden folder
     - Note: DPI might be too big, below Kindle PW 7th gen for Clara HD: 
     - ![Capture](./doc/img/nottrmnlogsupport.png)
     - Note: If using TERMINUS and PNG media/type, please [see guide to fix orientation](https://github.com/usetrmnl/trmnl-kobo/issues/17#issuecomment-3237420484), thanks [z0rzi](https://github.com/z0rzi)
-  - Default is:
+  - **IgnoreCurlErrors**: Set to `true` to ignore errors from `curl` commands during the TRMNL loop and retry in the next iteration. This will continue showing outdated screen rather than the error screen. Default is `false`. This is helpful for dodgy network connections.
+  - **WpaNetworkId**: Specifies the WPA network identifier to use. Default is `-1`, which means no specific network ID is set.
+    - You can get the id by ssh'ing into Kobo and running `wpa_cli list_networks`, using ID of the network you want. 
 ```
 {
     "TrmnlId": "your TRMNL Mac Address",

--- a/src/TRMNL/config.json
+++ b/src/TRMNL/config.json
@@ -5,5 +5,7 @@
     "DebugToScreen": 0,
     "LoopMaxIteration": 0,
     "ConnectedGracePeriod": 0,
-    "ImageFormat": "png" 
+    "ImageFormat": "png",
+    "IgnoreCurlErrors": "false",
+    "WpaNetworkId": "-1"
 }

--- a/src/TRMNL/scripts/enable-wifi.sh
+++ b/src/TRMNL/scripts/enable-wifi.sh
@@ -215,3 +215,5 @@ ifconfig "${INTERFACE}" up
 
 pkill -0 wpa_supplicant ||
     wpa_supplicant -D "${WPA_SUPPLICANT_DRIVER}" -s -i "${INTERFACE}" -c /etc/wpa_supplicant/wpa_supplicant.conf -C /var/run/wpa_supplicant -B
+
+./scripts/force-wifi-connection.sh >>/tmp/debug.log 2>&1

--- a/src/TRMNL/scripts/force-wifi-connection.sh
+++ b/src/TRMNL/scripts/force-wifi-connection.sh
@@ -1,0 +1,6 @@
+if [ "$trmnl_loop_wpa_network_id" -lt 0 ]; then
+    ./scripts/log.sh "Forcefully connecting to wifi"
+    wpa_cli enable_network $trmnl_loop_wpa_network_id > /dev/null 2>&1
+else
+    ./scripts/log.sh "No valid wpa network id to force connect"
+fi

--- a/src/TRMNL/scripts/force-wifi-connection.sh
+++ b/src/TRMNL/scripts/force-wifi-connection.sh
@@ -1,4 +1,4 @@
-if [ "$trmnl_loop_wpa_network_id" -lt 0 ]; then
+if [ "$trmnl_loop_wpa_network_id" -ge 0 ]; then
     ./scripts/log.sh "Forcefully connecting to wifi"
     wpa_cli enable_network $trmnl_loop_wpa_network_id > /dev/null 2>&1
 else

--- a/src/TRMNL/trmnl.sh
+++ b/src/TRMNL/trmnl.sh
@@ -19,6 +19,12 @@ export trmnl_loop_iteration_stop=$(jq -r '.LoopMaxIteration' config.json)
 # If 0, do not wait once connected to wifi, otherwise wait X sec to let user connect to SSH and troubleshoot
 export trmnl_loop_connected_grace_period=$(jq -r '.ConnectedGracePeriod' config.json)
 
+# Ignore errors on curl and just retry on next loop
+export trmnl_loop_ignore_curl_errors=$(jq -r '.IgnoreCurlErrors' config.json 2>/dev/null || echo "false")
+
+# WPA Network Identifier
+export trmnl_loop_wpa_network_id=$(jq -r '.WpaNetworkId' config.json 2>/dev/null || echo "-1")
+
 # Must me Major.Minor.Revision format
 export trmnl_firmware_version=$(cat version.txt)
 


### PR DESCRIPTION
2 features in 1 PR is a big no no usually but I don't wanna deal with it right now. Sorry :(

# Feature 1:
Uses `wpa_cli enable_network $trmnl_loop_wpa_network_id` so we don't need to wait for auto connect logic to kick in, _which it doesn't for some old kobos like my Nia._

In my opinion this makes `restore-wifi-async.sh` not useful, so it can be converted to sync and sleep 8s can be removed. But I would rather get this in and discuss that later.

# Feature 2:
Added a basic ignore errors support. Idea behind it is, if you are not debugging, and internet connection is little bit dodgy, I would rather have outdated screen than no screen.