### PR TITLE
Multiple fixes for stability and battery life

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,10 @@ Here are the steps to get the TRMNL app working on your Kobo (show hidden folder
   - **TrmnlToken**: Device token/API key
   - **TrmnlApiUrl**: Change this if your Bringing Your Own Server (BYOS)
   - **AppendApiPath**: Defaults to `"true"`, which appends `/api` to **TrmnlApiUrl** when it does not already end with it (any trailing slash is dropped first). Leaving `/api` off a BYOS url is an easy mistake to make. Set to `"false"` if your server really does serve the API from the root.
+  - **LogToServer**: How much of the log to POST to your server's `/log` endpoint. Case-sensitive, and any unrecognised value (including omitting the setting, or a typo such as `"debug"`) silently sends nothing.
+    - `"NONE"`: send nothing. This is the effective default.
+    - `"WARN"`: send only the warnings, such as failing to connect to the wifi or a failed suspend.
+    - `"DEBUG"`: send every log line. That is one HTTP request per line, a couple of dozen per refresh, each holding the wifi up a little longer, so prefer it for troubleshooting over everyday use.
   - **LoopMaxIteration**: Set to 0 to run indifinitely (for initial setup/troubeleshooting, pick a small number, so that the KOBO automatically restart)
   - **ConnectedGracePeriod**: Extra seconds to wait for the wifi to obtain an IP, on top of the 8s allowed by default. The wait ends as soon as an IP shows up, so raising this only matters if your KOBO regularly shows connection issues.
   - **ImageFormat**: bmp to behave like TRMNL OG, png, if you configured your device to something else (Kobo Libra, Kindle PW 7th gen for Clara HD).
@@ -81,6 +85,7 @@ Here are the steps to get the TRMNL app working on your Kobo (show hidden folder
     "TrmnlApiUrl": "https://usetrmnl.com/api",
     "AppendApiPath": "true",
     "DebugToScreen": 0,
+    "LogToServer": "NONE",
     "LoopMaxIteration": 0,
     "ConnectedGracePeriod": 0,
     "ImageFormat": "bmp" 

--- a/readme.md
+++ b/readme.md
@@ -96,12 +96,14 @@ Here are the steps to get the TRMNL app working on your Kobo (show hidden folder
   - (Located in src/nm/TRMNL.ini in this repo)
 - TRMNL app can be started using NickelMenu
    - ![Menu](./doc/img/menu.png) 
+- To exit the TRMNL loop, press the **home button**. The loop finishes its current cycle, then hands the Kobo back to its own UI without rebooting. On a device with no home button, or if it cannot be read, the loop logs a warning at startup and the method below still works. Note that the wifi is powered down on the way out and Kobo does not always notice, so you may have to toggle wifi off and on once in the Kobo settings.
 - To exit your Kobo when running the TRMNL loop, when powered off (sleeping between cycle), power it on (and release power button), and then hold the power button down until the power light blinks rapidly (or blue on mini). When the power light stops blinking, or lights up blue and glows solid, release the power button.
 
 
 ## FAQ
 - How to get out of TRMNL loop ?
-    - To exit your Kobo when running the TRMNL loop, when powered off (sleeping between cycle), power it on (and release power button), and then hold the power button down until the power light blinks rapidly (or blue on mini). When the power light stops blinking, or lights up blue and glows solid, release the power button.
+    - To exit the TRMNL loop, press the **home button**. The loop finishes its current cycle, then hands the Kobo back to its own UI without rebooting. On a device with no home button, or if it cannot be read, the loop logs a warning at startup and the method below still works. Note that the wifi is powered down on the way out and Kobo does not always notice, so you may have to toggle wifi off and on once in the Kobo settings.
+- To exit your Kobo when running the TRMNL loop, when powered off (sleeping between cycle), power it on (and release power button), and then hold the power button down until the power light blinks rapidly (or blue on mini). When the power light stops blinking, or lights up blue and glows solid, release the power button.
 - Why do sometimes I see a connection issue when KOBO's waking up ?
   - If your wifi connection is bad, it may take more time to connect than the 8s allowed by default, if this is the case, it can be fixed using ```ConnectedGracePeriod``` setting in config.json to increase the time to connect to the wifi.
 

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Here are the steps to get the TRMNL app working on your Kobo (show hidden folder
   - **TrmnlId**: Device Id/Mac address
   - **TrmnlToken**: Device token/API key
   - **TrmnlApiUrl**: Change this if your Bringing Your Own Server (BYOS)
+  - **AppendApiPath**: Defaults to `"true"`, which appends `/api` to **TrmnlApiUrl** when it does not already end with it (any trailing slash is dropped first). Leaving `/api` off a BYOS url is an easy mistake to make. Set to `"false"` if your server really does serve the API from the root.
   - **LoopMaxIteration**: Set to 0 to run indifinitely (for initial setup/troubeleshooting, pick a small number, so that the KOBO automatically restart)
   - **ConnectedGracePeriod**: Extra seconds to wait for the wifi to obtain an IP, on top of the 8s allowed by default. The wait ends as soon as an IP shows up, so raising this only matters if your KOBO regularly shows connection issues.
   - **ImageFormat**: bmp to behave like TRMNL OG, png, if you configured your device to something else (Kobo Libra, Kindle PW 7th gen for Clara HD).
@@ -78,6 +79,7 @@ Here are the steps to get the TRMNL app working on your Kobo (show hidden folder
     "TrmnlId": "your TRMNL Mac Address",
     "TrmnlToken": "your TRMNL API Key",
     "TrmnlApiUrl": "https://usetrmnl.com/api",
+    "AppendApiPath": "true",
     "DebugToScreen": 0,
     "LoopMaxIteration": 0,
     "ConnectedGracePeriod": 0,

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Here are the steps to get the TRMNL app working on your Kobo (show hidden folder
   - **TrmnlToken**: Device token/API key
   - **TrmnlApiUrl**: Change this if your Bringing Your Own Server (BYOS)
   - **LoopMaxIteration**: Set to 0 to run indifinitely (for initial setup/troubeleshooting, pick a small number, so that the KOBO automatically restart)
-  - **ConnectedGracePeriod**: If your KOBO regularly shows connection issue, increase this (delay in seconds after requesting to connect to the wifi, to request a TRMNL display information and image).
+  - **ConnectedGracePeriod**: Extra seconds to wait for the wifi to obtain an IP, on top of the 8s allowed by default. The wait ends as soon as an IP shows up, so raising this only matters if your KOBO regularly shows connection issues.
   - **ImageFormat**: bmp to behave like TRMNL OG, png, if you configured your device to something else (Kobo Libra, Kindle PW 7th gen for Clara HD).
     - Note: DPI might be too big, below Kindle PW 7th gen for Clara HD: 
     - ![Capture](./doc/img/nottrmnlogsupport.png)
@@ -96,7 +96,7 @@ Here are the steps to get the TRMNL app working on your Kobo (show hidden folder
 - How to get out of TRMNL loop ?
     - To exit your Kobo when running the TRMNL loop, when powered off (sleeping between cycle), power it on (and release power button), and then hold the power button down until the power light blinks rapidly (or blue on mini). When the power light stops blinking, or lights up blue and glows solid, release the power button.
 - Why do sometimes I see a connection issue when KOBO's waking up ?
-  - If your wifi connection is bad, it may takes more time than the alloted delay to connect to the Wifi, if this is the case, it can be fixed using ```ConnectedGracePeriod``` setting in config.json to increase the time to connect to the wifi.
+  - If your wifi connection is bad, it may take more time to connect than the 8s allowed by default, if this is the case, it can be fixed using ```ConnectedGracePeriod``` setting in config.json to increase the time to connect to the wifi.
 
 ## Digging into sources
 

--- a/src/TRMNL/config.json
+++ b/src/TRMNL/config.json
@@ -2,6 +2,7 @@
     "TrmnlId": "your TRMNL Mac Address",
     "TrmnlToken": "your TRMNL API Key",
     "TrmnlApiUrl": "https://usetrmnl.com/api",
+    "AppendApiPath": "true",
     "DebugToScreen": 0,
     "LoopMaxIteration": 0,
     "ConnectedGracePeriod": 0,

--- a/src/TRMNL/config.json
+++ b/src/TRMNL/config.json
@@ -4,6 +4,7 @@
     "TrmnlApiUrl": "https://usetrmnl.com/api",
     "AppendApiPath": "true",
     "DebugToScreen": 0,
+    "LogToServer": "NONE",
     "LoopMaxIteration": 0,
     "ConnectedGracePeriod": 0,
     "ImageFormat": "png",

--- a/src/TRMNL/lua/watch_key.lua
+++ b/src/TRMNL/lua/watch_key.lua
@@ -1,0 +1,59 @@
+-- Block on an input device until a key is pressed, then drop a flag file, so a
+-- shell script can react to a button without polling. Reading blocks, so this
+-- costs no CPU while it waits, and it is frozen along with everything else
+-- while the device is suspended.
+
+local ffi = require("ffi")
+local bor = bit.bor
+local C = ffi.C
+
+require("ffi/posix_h")
+
+-- 16 bytes here: struct timeval is two longs on 32 bit arm, then the u16 type
+-- and code and the s32 value
+ffi.cdef [[
+struct input_event {
+    long tv_sec;
+    long tv_usec;
+    unsigned short type;
+    unsigned short code;
+    int value;
+};
+]]
+
+assert(#arg == 3, "must pass an input device, a key code & a flag file")
+local device = arg[1]
+local key_code = tonumber(arg[2])
+local flag_file = arg[3]
+
+local EV_KEY = 1
+local KEY_PRESSED = 1
+
+local fd = C.open(device, bor(C.O_RDONLY, C.O_CLOEXEC))
+assert(fd ~= -1, "cannot open " .. device)
+
+local event = ffi.new("struct input_event[1]")
+local event_size = ffi.sizeof("struct input_event")
+local errors = 0
+
+while true do
+    local nread = C.read(fd, event, event_size)
+    if nread == event_size then
+        errors = 0
+        if event[0].type == EV_KEY and event[0].code == key_code and event[0].value == KEY_PRESSED then
+            local flag = assert(io.open(flag_file, "w"))
+            flag:write(key_code, "\n")
+            flag:close()
+            break
+        end
+    else
+        -- a thaw after suspend can cut a read short, so do not give up on the
+        -- first one, but do not spin forever on a device that has gone away
+        errors = errors + 1
+        if errors > 100 then
+            break
+        end
+    end
+end
+
+C.close(fd)

--- a/src/TRMNL/scripts/disable-wifi.sh
+++ b/src/TRMNL/scripts/disable-wifi.sh
@@ -105,7 +105,7 @@ case "${POWER_TOGGLE}" in
         # Poke the kernel via ioctl on platforms without the dedicated power module...
         if [ ! -e "/drivers/${PLATFORM}/wifi/sdio_wifi_pwr.ko" ]; then
             usleep 250000
-            ./luajit lua/ntx_io.lua 208 0
+            ./bin/luajit lua/ntx_io.lua 208 0
         fi
         ;;
 esac

--- a/src/TRMNL/scripts/enable-wifi.sh
+++ b/src/TRMNL/scripts/enable-wifi.sh
@@ -119,7 +119,7 @@ case "${POWER_TOGGLE}" in
                 insmod "${KMOD_PATH}/sdio_wifi_pwr.ko"
             else
                 # Poke the kernel via ioctl on platforms without the dedicated power module...
-                ./luajit frontend/device/kobo/ntx_io.lua 208 1
+                ./bin/luajit lua/ntx_io.lua 208 1
             fi
         fi
         ;;

--- a/src/TRMNL/scripts/getrssi.sh
+++ b/src/TRMNL/scripts/getrssi.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-test_string=$( iwconfig | grep -i "Signal level=" )
+# iwconfig separates the label from the value with '=' when the driver sets the
+# IW_QUAL_LEVEL_UPDATED bit and ':' when it doesn't, so accept either.
+test_string=$( iwconfig 2> /dev/null | grep -i "Signal level[:=]" )
 
 # --- Percentage to dBm Conversion Function ---
 # IMPORTANT: This is an EXAMPLE formula. Adjust it for your device!
@@ -37,13 +39,13 @@ convert_percentage_to_dbm() (
 # xargs is used to trim leading/trailing whitespace.
 raw_signal_info=""
 if [ -n "$test_string" ]; then # Process only if test_string is not empty
-    raw_signal_info=$(echo "$test_string" | awk -F 'Signal level=' '
+    raw_signal_info=$(echo "$test_string" | awk -F 'Signal level[:=]' '
         NF > 1 {
             # If "Signal level=" is found, $2 contains the rest of the line.
             # Now, isolate the value before " Noise level=" if it exists.
             # We use a general field separator for the second awk.
             print $2
-        }' | awk -F '[[:space:]]+Noise level=' '{print $1}' | xargs) # xargs trims
+        }' | awk -F '[[:space:]]+Noise level[:=]' '{print $1}' | xargs) # xargs trims
 fi
 
 # Check if extraction was successful

--- a/src/TRMNL/scripts/log.sh
+++ b/src/TRMNL/scripts/log.sh
@@ -48,7 +48,9 @@ if [ $debug_to_screen -ne 0 ]; then
     fbink -x 1 -y $value_to_save -S 2 "$1" > /dev/null 2>&1
 fi
 
-echo "$1" >>/tmp/debug.log 2>&1
+# Timestamped so sleep durations can be read off the log. The screen copy above
+# and the server copy below are left alone, they carry their own timing.
+echo "$(date +%T) ${2:-DEBUG} $1" >>/tmp/debug.log 2>&1
 
 if [ "$log_to_server" != "NONE" ]; then
 	if [ "$log_to_server" = "WARN" ] && [ "$2" = "WARN" ]; then

--- a/src/TRMNL/scripts/logToServer.sh
+++ b/src/TRMNL/scripts/logToServer.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 
-curl "${trmnl_apiurl}/log" -L \
+# The server takes its entries from a "logs" array of objects and silently ignores
+# any other shape while still answering 200, so a flat {"log":["msg"]} stored
+# nothing. jq builds the body so quotes and backslashes in the message, which our
+# own log lines carry, cannot produce invalid json.
+jq -nc --arg msg "$1" --arg ts "$(date +%s)" \
+	'{logs:[{message:$msg,creation_timestamp:($ts|tonumber)}]}' |
+# -s -o /dev/null: this runs once per log line, the progress meter and the response
+# body were going straight to the console
+curl "${trmnl_apiurl}/log" -L -s -o /dev/null \
 	 -H "ID: $trmnl_id" \
 	 -H "Access-Token: $trmnl_token" \
 	 -H "Content-Type: application/json" \
@@ -8,5 +16,4 @@ curl "${trmnl_apiurl}/log" -L \
 	 -H "RSSI: $rssi" \
 	 -H "FW-Version: ${trmnl_firmware_version}" \
 	 --request POST \
-	 --data '{"log":["'"$1"'"]}'
-
+	 --data @-

--- a/src/TRMNL/scripts/logToServer.sh
+++ b/src/TRMNL/scripts/logToServer.sh
@@ -9,6 +9,7 @@ jq -nc --arg msg "$1" --arg ts "$(date +%s)" \
 # -s -o /dev/null: this runs once per log line, the progress meter and the response
 # body were going straight to the console
 curl "${trmnl_apiurl}/log" -L -s -o /dev/null \
+	 --fail --connect-timeout 15 --max-time 30 \
 	 -H "ID: $trmnl_id" \
 	 -H "Access-Token: $trmnl_token" \
 	 -H "Content-Type: application/json" \
@@ -17,3 +18,7 @@ curl "${trmnl_apiurl}/log" -L -s -o /dev/null \
 	 -H "FW-Version: ${trmnl_firmware_version}" \
 	 --request POST \
 	 --data @-
+status=$?
+if [ $status -ne 0 ]; then # straight to the log, log.sh would recurse back here
+	echo "[$(date)] logToServer.sh: POST failed ($status)" >>/tmp/debug.log
+fi

--- a/src/TRMNL/scripts/logToServer.sh
+++ b/src/TRMNL/scripts/logToServer.sh
@@ -4,7 +4,7 @@ curl "${trmnl_apiurl}/log" -L \
 	 -H "ID: $trmnl_id" \
 	 -H "Access-Token: $trmnl_token" \
 	 -H "Content-Type: application/json" \
-	 -H "Battery-Voltage: $trmnl_fake_voltage" \
+	 -H "Percent-Charged: $batteryCapacity" \
 	 -H "RSSI: $rssi" \
 	 -H "FW-Version: ${trmnl_firmware_version}" \
 	 --request POST \

--- a/src/TRMNL/scripts/obtain-ip.sh
+++ b/src/TRMNL/scripts/obtain-ip.sh
@@ -49,7 +49,7 @@ for fd in /proc/"$$"/fd/*; do
     fi
 done
 
-./release-ip.sh
+./scripts/release-ip.sh
 
 # NOTE: Prefer dhcpcd over udhcpc if available. That's what Nickel uses,
 #       and udhcpc appears to trip some insanely wonky corner cases on current FW (#6421)

--- a/src/TRMNL/scripts/restore-nickel.sh
+++ b/src/TRMNL/scripts/restore-nickel.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# Hand the Kobo back to its own UI without a reboot, following KOReader's
+# platform/kobo/nickel.sh. trmnl.sh killed nickel, switched the framebuffer and
+# changed the cpu governor on the way in, so all of that has to be undone first.
+# Must run from the TRMNL directory, before the cd below.
+
+if [ ! -x /usr/local/Kobo/nickel ]; then
+    ./scripts/log.sh "No nickel to restore, leaving the device as it is" "WARN"
+    exit 1
+fi
+
+# Nickel does not like finding the wifi up (koreader #1520)
+./scripts/log.sh "Restoring nickel, disabling wifi first" "DEBUG"
+./scripts/disable-wifi.sh >>/tmp/debug.log 2>&1
+
+# Put the framebuffer back the way nickel expects it, or its UI comes up garbled
+if [ -n "${ORIG_FB_BPP}" ]; then
+    ./bin/fbink/fbdepth -d "${ORIG_FB_BPP}" -r "${ORIG_FB_ROTA}" >>/tmp/debug.log 2>&1
+fi
+if [ -n "${ORIG_CPUFREQ_GOV}" ] && [ -n "${CPUFREQ_SYSFS_PATH}" ]; then
+    echo "${ORIG_CPUFREQ_GOV}" >"${CPUFREQ_SYSFS_PATH}/scaling_governor"
+fi
+
+# Clear our own stuff out of the environment, USBMS gets wonky otherwise
+cd / || exit 1
+unset OLDPWD
+unset LC_ALL
+export LD_LIBRARY_PATH="/usr/local/Kobo"
+
+if [ -e "/etc/init.d/on-animator.sh" ]; then
+    # nickel kills on-animator.sh on start, so there is nothing to reap
+    (
+        usleep 400000
+        /etc/init.d/on-animator.sh
+    ) &
+fi
+
+if [ -e "/etc/init.d/z-nickel-hardware-status" ]; then
+    # FW 5 has its own startup scripts, the prefix gets prepended by them
+    unset LD_LIBRARY_PATH
+    /etc/init.d/z-nickel-hardware-status
+    sync
+    /etc/rc.local
+else
+    # Recreate the FIFO rcS makes and trmnl.sh removed: udev writes to it and
+    # nickel reads it
+    rm -f /tmp/nickel-hardware-status
+    mkfifo /tmp/nickel-hardware-status
+
+    sync
+
+    /usr/local/Kobo/hindenburg &
+    LIBC_FATAL_STDERR_=1 /usr/local/Kobo/nickel -platform kobo -skipFontLoad &
+    [ "${PLATFORM}" != "freescale" ] && udevadm trigger &
+fi
+
+exit 0

--- a/src/TRMNL/scripts/restore-wifi-async.sh
+++ b/src/TRMNL/scripts/restore-wifi-async.sh
@@ -12,7 +12,7 @@ RestoreWifi() {
         # If wpa_supplicant hasn't connected within 15 seconds, assume it never will, and tear down Wi-Fi
         if [ ${wpac_timeout} -ge 60 ]; then
             echo "[$(date)] restore-wifi-async.sh: Failed to connect to preferred AP!"
-            ./disable-wifi.sh
+            ./scripts/disable-wifi.sh
             return 1
         fi
         usleep 250000

--- a/src/TRMNL/scripts/wait-for-ip.sh
+++ b/src/TRMNL/scripts/wait-for-ip.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Wait for an IPv4 address on any interface but lo, i.e. wifi associated and DHCP done.
+# Usage: wait-for-ip.sh [timeout_seconds]. Exits 0 once found, 1 on timeout.
+
+timeout=${1:-8}
+case "$timeout" in # config.json is user edited
+    '' | *[!0-9]*) timeout=8 ;;
+esac
+
+# No-arg ifconfig lists only interfaces that are up (do not switch to -a).
+# 169.254/16 is dhcpcd's IPv4LL fallback, i.e. DHCP failed, so it is not success.
+# The wifi interface is not always wlan0 (INTERFACE defaults to eth0 on Kobo).
+FindIp() {
+    ifconfig 2>/dev/null | awk '
+        /^[^ \t]/ { iface = $1; sub(/:$/, "", iface) }   # stanza header
+        /inet6/   { next }
+        /inet/ {
+            if (iface == "lo") next
+            addr = $0
+            sub(/^.*inet[ \t]*(addr:)?[ \t]*/, "", addr)
+            sub(/[^0-9.].*$/, "", addr)
+            if (addr != "" && addr != "0.0.0.0" && addr !~ /^169\.254\./) {
+                print iface " " addr
+                found = 1
+                exit
+            }
+        }
+        END { exit !found }
+    '
+}
+
+ticks=0 # 250ms each
+max_ticks=$((timeout * 4))
+while :; do
+    if found_ip=$(FindIp); then
+        echo "[$(date)] wait-for-ip.sh: got ${found_ip} after $((ticks / 4))s"
+        exit 0
+    fi
+
+    if [ ${ticks} -ge ${max_ticks} ]; then
+        # measured, not ${timeout}: they diverge if usleep is missing and the loop spins
+        echo "[$(date)] wait-for-ip.sh: still no IP after $((ticks / 4))s, giving up"
+        exit 1
+    fi
+
+    usleep 250000
+    ticks=$((ticks + 1))
+done

--- a/src/TRMNL/scripts/watch-stop-button.sh
+++ b/src/TRMNL/scripts/watch-stop-button.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Drop $1 when the home button is pressed, so the loop can stop without the
+# hold-power reboot.
+#
+# NOTE: Nickel grabs the input device exclusively, so this sees nothing until
+#       trmnl.sh has killed it. That is the normal case here.
+# NOTE: The home button shares its node with the power button, which is how the
+#       device is woken, so the key code matters: reacting to any key would stop
+#       the loop on every wake.
+
+FLAG=${1:-/tmp/trmnl_stop}
+KEY_HOME=102
+
+# input_scan prints its matches as CSV, take the first
+device=$(./bin/fbink/input_scan -q -p -m home -x touchscreen 2>/dev/null | cut -d, -f1)
+if [ -z "$device" ] || [ ! -e "$device" ]; then
+    ./scripts/log.sh "No home button found, it cannot be used to stop the loop" "WARN"
+    exit 0
+fi
+
+./scripts/log.sh "Watching ${device} for the home button" "DEBUG"
+exec ./bin/luajit lua/watch_key.lua "$device" "$KEY_HOME" "$FLAG"

--- a/src/TRMNL/trmnl.sh
+++ b/src/TRMNL/trmnl.sh
@@ -406,6 +406,10 @@ while true; do
     fi
 done
 
+# The radio went down with the last suspend, so server logging from here on
+# would only block on connect timeouts
+export log_to_server="NONE"
+
 pkill -f watch_key.lua
 rm -f "${TRMNL_STOP_FLAG}"
 

--- a/src/TRMNL/trmnl.sh
+++ b/src/TRMNL/trmnl.sh
@@ -377,6 +377,17 @@ ko_do_dns
 # ensure hardware clock and system time are in sync
 hwclock -w -u
 
+# restore-nickel.sh runs as a child and has to undo what we changed on the way in
+export ORIG_FB_BPP ORIG_FB_ROTA ORIG_CPUFREQ_GOV CPUFREQ_SYSFS_PATH
+
+# The home button is the way out of the loop, without the hold-power reboot. The
+# watcher holds the input device open for the whole run, because a press is
+# dropped by the kernel if nothing has it open, and we are asleep most of the time.
+export TRMNL_STOP_FLAG=/tmp/trmnl_stop
+rm -f "${TRMNL_STOP_FLAG}"
+./scripts/watch-stop-button.sh "${TRMNL_STOP_FLAG}" >>/tmp/debug.log 2>&1 &
+
+stopped_by_button="false"
 while true; do
     count=$((count + 1))
     ./scripts/log.sh "$(date +%T) >> Loop ${count}" "DEBUG"
@@ -384,11 +395,19 @@ while true; do
 
     # logging everything block the suspend
     ./trmnlloop.sh
+    if [ -e "${TRMNL_STOP_FLAG}" ]; then
+        ./scripts/log.sh "Home button pressed, stopping after $count iterations." "DEBUG"
+        stopped_by_button="true"
+        break
+    fi
     if [ $count -eq $trmnl_loop_iteration_stop ] && [ $trmnl_loop_iteration_stop -ne 0 ]; then
         ./scripts/log.sh "Stopping script after $count iterations." "DEBUG"
         break
     fi
 done
+
+pkill -f watch_key.lua
+rm -f "${TRMNL_STOP_FLAG}"
 
 # Wipe the clones on exit
 rm -f "/tmp/trmnl.sh"
@@ -398,6 +417,13 @@ if [ -e /tmp/debug.log ]; then
     mv -f /tmp/debug.log.new /tmp/debug.log
 fi
 cp /tmp/debug.log debug.log
+
+# Stopping with the button is meant to avoid the reboot, so hand the device back
+# to nickel instead. Every other way out still reboots, as it always did.
+if [ "${stopped_by_button}" = "true" ]; then
+    ./scripts/restore-nickel.sh && exit 0
+    ./scripts/log.sh "Could not restore nickel, rebooting instead" "WARN"
+fi
 
 reboot
 exit 0

--- a/src/TRMNL/trmnl.sh
+++ b/src/TRMNL/trmnl.sh
@@ -228,10 +228,15 @@ fi
 
 # Make sure we have a sane-ish INTERFACE env var set...
 if [ -z "${INTERFACE}" ]; then
-    # That's what we used to hardcode anyway
-    INTERFACE="eth0"
+    # Ask the kernel instead of guessing: it is eth0 on the older Kobos but wlan0
+    # on others, and every wifi script here silently operates on a device that
+    # does not exist if we get it wrong. Only lists drivers already loaded, so
+    # keep eth0 as the last resort.
+    INTERFACE=$(awk 'NR > 2 { sub(":", "", $1); print $1; exit }' /proc/net/wireless 2>/dev/null)
+    INTERFACE="${INTERFACE:-eth0}"
     export INTERFACE
 fi
+echo "Wifi interface in use: $INTERFACE" >>/tmp/debug.log 2>&1
 
 # We'll enforce UR in ko_do_fbdepth, so make sure further FBInk usage (USBMS)
 # will also enforce UR... (Only actually meaningful on sunxi).

--- a/src/TRMNL/trmnl.sh
+++ b/src/TRMNL/trmnl.sh
@@ -10,6 +10,19 @@ export trmnl_token="$(jq -r '.TrmnlToken' config.json)"
 # Change if BYOS, no trailing slash
 export trmnl_apiurl="$(jq -r '.TrmnlApiUrl' config.json)"
 
+# Leaving /api off a BYOS url is a common mistake, so append it unless told not
+# to. jq -r renders "false" and false alike, and null when the key is absent.
+if [ "$(jq -r '.AppendApiPath' config.json 2>/dev/null)" != "false" ]; then
+    while [ "${trmnl_apiurl%/}" != "$trmnl_apiurl" ]; do # also catches ".../api/"
+        trmnl_apiurl="${trmnl_apiurl%/}"
+    done
+    case "$trmnl_apiurl" in
+        */api) ;;
+        *) trmnl_apiurl="${trmnl_apiurl}/api" ;;
+    esac
+fi
+echo "Api url in use: $trmnl_apiurl" >>/tmp/debug.log 2>&1
+
 # Do not log to screen if 0, otherwise log to screen too
 export debug_to_screen=$(jq -r '.DebugToScreen' config.json)
 

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -1,16 +1,107 @@
 #!/bin/sh
 
+# Every trmnlloop.sh run is its own process, so the backoff state lives in /tmp,
+# which survives suspend to memory
+LAST_REFRESH_FILE=/tmp/trmnl_last_refresh
+FAILURE_COUNT_FILE=/tmp/trmnl_failures
+FIRST_RETRY_DELAY=60
+DEFAULT_REFRESH=900
+
+# Echo $1 if it is a positive integer, $2 otherwise
+SaneSeconds() {
+    case "$1" in
+        '' | *[!0-9]* | 0) echo "$2" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+# Shut the wifi down and suspend to memory for $1 seconds
+SuspendFor() {
+    suspend_seconds=$1
+
+    # A RestoreWifi still in its wpa wait would otherwise thaw after the suspend
+    # and tear down the wifi the next iteration just brought up
+    pkill -f restore-wifi-async.sh
+
+    ./scripts/log.sh "disabling wifi" "DEBUG"
+    ./scripts/disable-wifi.sh >>/tmp/debug.log 2>&1
+
+    ./scripts/log.sh "Should sleep for ${suspend_seconds}" "DEBUG"
+    sleep 5s
+
+    ./scripts/log.sh "Enable suspend state" "DEBUG"
+    echo 1 >/sys/power/state-extended >>/tmp/debug.log 2>&1
+    if [ $? -eq 0 ]; then
+        ./scripts/log.sh "Enabled suspend state ok" "DEBUG"
+    else
+        ./scripts/log.sh "Enable suspend state failed" "WARN"
+    fi
+
+    ./scripts/log.sh "Setting up rtcwake alarm" "DEBUG"
+
+    # Record the start time
+    start_time=$(date +%s)
+    ./bin/busybox_kobo rtcwake -a -s $suspend_seconds -m mem >>/tmp/debug.log 2>&1
+    if [ $? -eq 0 ]; then
+        ./scripts/log.sh "rtcwake ok"
+    else
+        ./scripts/log.sh "rtcwake failed, will try secondary suspend to memory next" "WARN"
+    fi
+
+    # Calculate the elapsed time
+    elapsed_time_in_rtcwake=$(($(date +%s) - start_time))
+
+    # Check if the elapsed time is greater than 10 seconds
+    if [ "$elapsed_time_in_rtcwake" -gt 10 ]; then
+        ./scripts/log.sh "rtcwake took more than 10 seconds, skipping suspend to mem in power state" "WARN"
+    else
+        ./scripts/log.sh  "rtcwake took ${elapsed_time_in_rtcwake}, writing suspend to mem in power state" "DEBUG"
+        ./scripts/ledToggle.sh 0  >>/tmp/debug.log 2>&1
+        sleep 1s
+        sync
+        sleep 2s
+        echo mem >/sys/power/state
+        if [ $? -eq 0 ]; then
+            ./scripts/log.sh "Suspend to mem ok" "DEBUG"
+        else
+            ./scripts/log.sh "Suspend to mem failed" "DEBUG"
+        fi
+
+        ./scripts/log.sh "Disable suspend state" "DEBUG"
+        echo 0 >/sys/power/state-extended >>/tmp/debug.log 2>&1
+        if [ $? -eq 0 ]; then
+            ./scripts/log.sh "Disabled suspend state ok" "DEBUG"
+        else
+            ./scripts/log.sh "Disable suspend state failed" "WARN"
+        fi
+    fi
+}
+
 function ErrorOnCurl(){
     if [ "$trmnl_loop_ignore_curl_errors" = "true" ]; then
         ./scripts/log.sh "Ignoring curl error as per configuration"
         return
-    else
-        ./bin/fbink/fbdepth -r 0
-        ./bin/fbink/fbink -q -g file=./bin/error.png,valign=CENTER,halign=CENTER,h=-2,w=0 -c -f > /dev/null 2>&1
-        ./bin/fbink/fbink -m -y 5 "Retrieve TRMNL Display info failed ($curl_status)"  > /dev/null 2>&1
-        ./bin/fbink/fbdepth -r -1
-        sleep 15s
     fi
+
+    ./bin/fbink/fbdepth -r 0
+    ./bin/fbink/fbink -q -g file=./bin/error.png,valign=CENTER,halign=CENTER,h=-2,w=0 -c -f > /dev/null 2>&1
+    ./bin/fbink/fbink -m -y 5 "Retrieve TRMNL Display info failed ($curl_status)"  > /dev/null 2>&1
+    ./bin/fbink/fbdepth -r -1
+
+    failures=$(cat "$FAILURE_COUNT_FILE" 2>/dev/null)
+    failures=$(($(SaneSeconds "$failures" 0) + 1))
+    echo "$failures" >"$FAILURE_COUNT_FILE"
+
+    if [ $failures -eq 1 ]; then
+        # One quick retry, the network is often back within the minute
+        retry_in=$FIRST_RETRY_DELAY
+    else
+        # Still down, settle back to whatever rate the server last asked for
+        retry_in=$(SaneSeconds "$(cat "$LAST_REFRESH_FILE" 2>/dev/null)" $DEFAULT_REFRESH)
+    fi
+
+    ./scripts/log.sh "Failure ${failures}, suspending for ${retry_in}s" "WARN"
+    SuspendFor $retry_in
 }
 
 
@@ -104,58 +195,9 @@ else
         # rotate back to portrait mode
         ./bin/fbink/fbdepth -r -1
 
-        ./scripts/log.sh "disabling wifi" "DEBUG"
-        ./scripts/disable-wifi.sh >>/tmp/debug.log 2>&1
-
-        refresh_rate=$(jq -r '.refresh_rate' /tmp/trmnl.json)
-        ./scripts/log.sh "Should sleep for ${refresh_rate}" "DEBUG"
-        sleep 5s
-
-        ./scripts/log.sh "Enable suspend state" "DEBUG"
-        echo 1 >/sys/power/state-extended >>/tmp/debug.log 2>&1
-        if [ $? -eq 0 ]; then
-            ./scripts/log.sh "Enabled suspend state ok" "DEBUG"
-        else
-            ./scripts/log.sh "Enable suspend state failed" "WARN"
-        fi
-
-        ./scripts/log.sh "Setting up rtcwake alarm" "DEBUG"
-
-        # Record the start time
-        start_time=$(date +%s)
-        ./bin/busybox_kobo rtcwake -a -s $refresh_rate -m mem >>/tmp/debug.log 2>&1
-        if [ $? -eq 0 ]; then
-            ./scripts/log.sh "rtcwake ok"
-        else
-            ./scripts/log.sh "rtcwake failed, will try secondary suspend to memory next" "WARN"
-        fi
-
-        # Calculate the elapsed time
-        elapsed_time_in_rtcwake=$(($(date +%s) - start_time))
-
-        # Check if the elapsed time is greater than 10 seconds
-        if [ "$elapsed_time_in_rtcwake" -gt 10 ]; then
-            ./scripts/log.sh "rtcwake took more than 10 seconds, skipping suspend to mem in power state" "WARN"
-        else
-            ./scripts/log.sh  "rtcwake took ${elapsed_time_in_rtcwake}, writing suspend to mem in power state" "DEBUG"
-            ./scripts/ledToggle.sh 0  >>/tmp/debug.log 2>&1
-            sleep 1s
-            sync
-            sleep 2s
-            echo mem >/sys/power/state
-            if [ $? -eq 0 ]; then
-                ./scripts/log.sh "Suspend to mem ok" "DEBUG"
-            else
-                ./scripts/log.sh "Suspend to mem failed" "DEBUG"
-            fi
-
-            ./scripts/log.sh "Disable suspend state" "DEBUG"
-            echo 0 >/sys/power/state-extended >>/tmp/debug.log 2>&1
-            if [ $? -eq 0 ]; then
-                ./scripts/log.sh "Disabled suspend state ok" "DEBUG"
-            else
-                ./scripts/log.sh "Disable suspend state failed" "WARN"
-            fi
-        fi
+        refresh_rate=$(SaneSeconds "$(jq -r '.refresh_rate' /tmp/trmnl.json)" $DEFAULT_REFRESH)
+        echo "$refresh_rate" >"$LAST_REFRESH_FILE"
+        rm -f "$FAILURE_COUNT_FILE"
+        SuspendFor $refresh_rate
     fi
 fi

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -54,6 +54,13 @@ else
   ./scripts/log.sh "Error: Could not find battery information." "DEBUG"
 fi
 
+# Battery-Charging is a 0/1 boolean. power_supply status is one of Charging,
+# Discharging, Not charging, Full or Unknown, so only the first one counts.
+case "$batteryStatus" in
+    Charging) batteryCharging=1 ;;
+    *) batteryCharging=0 ;;
+esac
+
 ./scripts/log.sh "Battery capacity: ${batteryCapacity}% - Status: ${batteryStatus}" "DEBUG"
 
 # get signal quality
@@ -63,6 +70,7 @@ curl "${trmnl_apiurl}/display" -L \
     -H "ID: $trmnl_id" \
     -H "Access-Token: $trmnl_token" \
     -H "Percent-Charged: $batteryCapacity" \
+    -H "Battery-Charging: $batteryCharging" \
     -H "RSSI: $rssi" \
     -H "FW-Version: ${trmnl_firmware_version}" \
     -o /tmp/trmnl.json >>/tmp/debug.log 2>&1

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -21,9 +21,19 @@ function ErrorOnCurl(){
 
 ./scripts/log.sh "restore wifi" "DEBUG"
 ./scripts/restore-wifi-async.sh >>/tmp/debug.log 2>&1
-sleep 8s # give time to the kobo to reconnect (KOBO mini is okay with 5s, clara needs more)
 
-sleep $trmnl_loop_connected_grace_period
+# restore-wifi-async.sh connects in the background: wait for the IP instead of a
+# fixed sleep, so the radio is powered back down sooner. ConnectedGracePeriod
+# stretches the budget for slow connections.
+# NOTE: ErrorOnCurl leaves the wifi up, so after a failed iteration this returns
+#       at once on the previous lease, which release-ip.sh is about to drop. That
+#       curl likely fails too, and the iteration after it connects normally.
+grace=$trmnl_loop_connected_grace_period
+case "$grace" in # "null" if missing from config.json
+    '' | *[!0-9]*) grace=0 ;;
+esac
+./scripts/wait-for-ip.sh $((8 + grace)) >>/tmp/debug.log 2>&1 ||
+    ./scripts/log.sh "No IP obtained, trying to reach TRMNL anyway" "WARN"
 
 
 # Check if the battery directory exists

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -6,6 +6,7 @@ LAST_REFRESH_FILE=/tmp/trmnl_last_refresh
 FAILURE_COUNT_FILE=/tmp/trmnl_failures
 FIRST_RETRY_DELAY=60
 DEFAULT_REFRESH=900
+MAX_SUSPEND_ATTEMPTS=5
 
 # Echo $1 if it is a positive integer, $2 otherwise
 SaneSeconds() {
@@ -15,19 +16,9 @@ SaneSeconds() {
     esac
 }
 
-# Shut the wifi down and suspend to memory for $1 seconds
-SuspendFor() {
+# One suspend attempt, for $1 seconds
+SuspendOnce() {
     suspend_seconds=$1
-
-    # A RestoreWifi still in its wpa wait would otherwise thaw after the suspend
-    # and tear down the wifi the next iteration just brought up
-    pkill -f restore-wifi-async.sh
-
-    ./scripts/log.sh "disabling wifi" "DEBUG"
-    ./scripts/disable-wifi.sh >>/tmp/debug.log 2>&1
-
-    ./scripts/log.sh "Should sleep for ${suspend_seconds}" "DEBUG"
-    sleep 5s
 
     ./scripts/log.sh "Enable suspend state" "DEBUG"
     echo 1 >/sys/power/state-extended >>/tmp/debug.log 2>&1
@@ -85,6 +76,42 @@ SuspendFor() {
             ./scripts/log.sh "Disable suspend state failed" "WARN"
         fi
     fi
+}
+
+# Shut the wifi down and stay suspended for $1 seconds. A suspend can come back
+# early, from a stray wakeup source rather than our alarm, and simply carrying on
+# would spend a whole wifi-and-fetch iteration well before the refresh is due, so
+# serve out the remaining time instead. Bounded, so something waking us
+# constantly cannot trap us here.
+SuspendFor() {
+    total_seconds=$1
+
+    # A RestoreWifi still in its wpa wait would otherwise thaw after the suspend
+    # and tear down the wifi the next iteration just brought up
+    pkill -f restore-wifi-async.sh
+
+    ./scripts/log.sh "disabling wifi" "DEBUG"
+    ./scripts/disable-wifi.sh >>/tmp/debug.log 2>&1
+
+    ./scripts/log.sh "Should sleep for ${total_seconds}" "DEBUG"
+    sleep 5s
+
+    deadline=$(($(date +%s) + total_seconds))
+    attempt=0
+    while :; do
+        remaining=$((deadline - $(date +%s)))
+        # close enough, another suspend would cost more than it saves
+        [ $remaining -le 10 ] && break
+
+        attempt=$((attempt + 1))
+        if [ $attempt -gt $MAX_SUSPEND_ATTEMPTS ]; then
+            ./scripts/log.sh "still ${remaining}s short after ${MAX_SUSPEND_ATTEMPTS} suspends, carrying on" "WARN"
+            break
+        fi
+        [ $attempt -gt 1 ] && ./scripts/log.sh "woken ${remaining}s early, suspending again" "WARN"
+
+        SuspendOnce $remaining
+    done
 }
 
 function ErrorOnCurl(){

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -94,6 +94,10 @@ SuspendFor() {
 
     ./scripts/log.sh "disabling wifi" "DEBUG"
     ./scripts/disable-wifi.sh >>/tmp/debug.log 2>&1
+    # Nothing reaches the server with the radio off and each attempt blocks for
+    # the connect timeout, so stop trying. The next iteration is a new process
+    # and picks the configured level back up.
+    export log_to_server="NONE"
 
     ./scripts/log.sh "Should sleep for ${total_seconds}" "DEBUG"
     sleep 5s

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -83,10 +83,10 @@ function ErrorOnCurl(){
         return
     fi
 
-    ./bin/fbink/fbdepth -r 0
-    ./bin/fbink/fbink -q -g file=./bin/error.png,valign=CENTER,halign=CENTER,h=-2,w=0 -c -f > /dev/null 2>&1
-    ./bin/fbink/fbink -m -y 5 "Retrieve TRMNL Display info failed ($curl_status)"  > /dev/null 2>&1
-    ./bin/fbink/fbdepth -r -1
+    ./bin/fbink/fbdepth -r 0 >>/tmp/debug.log 2>&1
+    ./bin/fbink/fbink -q -g file=./bin/error.png,valign=CENTER,halign=CENTER,h=-2,w=0 -c -f >>/tmp/debug.log 2>&1
+    ./bin/fbink/fbink -m -y 5 "Retrieve TRMNL Display info failed ($curl_status)" >>/tmp/debug.log 2>&1
+    ./bin/fbink/fbdepth -r -1 >>/tmp/debug.log 2>&1
 
     failures=$(cat "$FAILURE_COUNT_FILE" 2>/dev/null)
     failures=$(($(SaneSeconds "$failures" 0) + 1))
@@ -188,12 +188,19 @@ else
         # With png image is already in portrait, no need to rotate, with bmp/legacy, rotation is needed, it here that we should support reverse orientation
         if [ "$trmnl_image_format" = "bmp" ]; then
             # Rotation -r 0 break BMP rendering, rotate it 180 more to go from portrait to landscape inverted
-            ./bin/fbink/fbdepth -r 2
+            ./bin/fbink/fbdepth -r 2 >>/tmp/debug.log 2>&1
         fi
-        ./bin/fbink/fbink -g file=/tmp/trmnl.$trmnl_image_format,valign=CENTER,halign=CENTER,h=-2,w=0 -c -f
+        ./bin/fbink/fbink -g file=/tmp/trmnl.$trmnl_image_format,valign=CENTER,halign=CENTER,h=-2,w=0 -c -f >>/tmp/debug.log 2>&1
+        fbink_status=$?
+        image_bytes=$(wc -c < /tmp/trmnl.$trmnl_image_format 2>/dev/null)
+        if [ $fbink_status -eq 0 ]; then
+            ./scripts/log.sh "Displayed ${trmnl_image_format} image of ${image_bytes} bytes" "DEBUG"
+        else
+            ./scripts/log.sh "fbink failed on ${trmnl_image_format} image of ${image_bytes} bytes (${fbink_status})" "WARN"
+        fi
 
         # rotate back to portrait mode
-        ./bin/fbink/fbdepth -r -1
+        ./bin/fbink/fbdepth -r -1 >>/tmp/debug.log 2>&1
 
         refresh_rate=$(SaneSeconds "$(jq -r '.refresh_rate' /tmp/trmnl.json)" $DEFAULT_REFRESH)
         echo "$refresh_rate" >"$LAST_REFRESH_FILE"

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -56,6 +56,16 @@ SuspendFor() {
         ./scripts/log.sh "rtcwake took more than 10 seconds, skipping suspend to mem in power state" "WARN"
     else
         ./scripts/log.sh  "rtcwake took ${elapsed_time_in_rtcwake}, writing suspend to mem in power state" "DEBUG"
+        # rtcwake turns the alarm back off when it resumes, so the suspend below
+        # would have no wakeup source at all and only stir on an outside event
+        echo 0 >/sys/class/rtc/rtc0/wakealarm 2>>/tmp/debug.log
+        echo "+${suspend_seconds}" >/sys/class/rtc/rtc0/wakealarm 2>>/tmp/debug.log
+        wakealarm=$(cat /sys/class/rtc/rtc0/wakealarm 2>/dev/null)
+        if [ -n "$wakealarm" ] && [ "$wakealarm" != "0" ]; then
+            ./scripts/log.sh "wakealarm armed for ${suspend_seconds}s (at ${wakealarm})" "DEBUG"
+        else
+            ./scripts/log.sh "could not arm wakealarm, suspend has no timer" "WARN"
+        fi
         ./scripts/ledToggle.sh 0  >>/tmp/debug.log 2>&1
         sleep 1s
         sync

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -64,6 +64,8 @@ esac
 ./scripts/log.sh "Battery capacity: ${batteryCapacity}% - Status: ${batteryStatus}" "DEBUG"
 
 # get signal quality
+# (exported so logToServer.sh, which runs as a grandchild, can report it too)
+export rssi
 rssi=$(./scripts/getrssi.sh)
 
 curl "${trmnl_apiurl}/display" -L \

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -68,7 +68,9 @@ esac
 export rssi
 rssi=$(./scripts/getrssi.sh)
 
-curl "${trmnl_apiurl}/display" -L \
+# --fail so an HTTP error is not parsed as a payload, and time limits so a
+# stalled server cannot hold the radio on indefinitely
+curl "${trmnl_apiurl}/display" -L --fail --connect-timeout 15 --max-time 30 \
     -H "ID: $trmnl_id" \
     -H "Access-Token: $trmnl_token" \
     -H "Percent-Charged: $batteryCapacity" \
@@ -84,7 +86,9 @@ if [ $curl_status -ne 0 ]; then
     ErrorOnCurl
 else
     image_url=$(jq -r '.image_url' /tmp/trmnl.json)
-    curl -L -o /tmp/trmnl.$trmnl_image_format "${image_url}" >>/tmp/debug.log 2>&1
+    # Longer ceiling than the display request, the image is much bigger
+    curl -L --fail --connect-timeout 15 --max-time 60 \
+        -o /tmp/trmnl.$trmnl_image_format "${image_url}" >>/tmp/debug.log 2>&1
     curl_status=$?
     ./scripts/log.sh "TRMNL fetch image from ${image_url} returned ${curl_status}" "DEBUG"
     if [ $curl_status -ne 0 ]; then

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -37,6 +37,8 @@ esac
 
 
 # Check if the battery directory exists
+# (exported so logToServer.sh, which runs as a grandchild, can report it too)
+export batteryCapacity
 if [ -d /sys/class/power_supply/mc13892_bat ]; then
   # Set variables from the second possible path
   batteryCapacity=$(cat /sys/class/power_supply/mc13892_bat/capacity)
@@ -52,19 +54,7 @@ else
   ./scripts/log.sh "Error: Could not find battery information." "DEBUG"
 fi
 
-# 4.08 = 90% => 4.19 = 100 %
-# 3.12 = 10% => 3.00 = 0 %
-
-trmnl_low_mv=3000
-trmnl_high_mv=4195
-
-range_mv=$((trmnl_high_mv - trmnl_low_mv))
-voltage_mv=$(( (batteryCapacity * range_mv / 100) + trmnl_low_mv ))
-
-# Convert back to voltage with decimal using string manipulation
-trmnl_fake_voltage="${voltage_mv:0:${#voltage_mv}-3}.${voltage_mv: -3}"
-
-./scripts/log.sh "Battery capacity: ${batteryCapacity}%- Status: ${batteryStatus} - Voltage for API: ${trmnl_fake_voltage}V" "DEBUG"
+./scripts/log.sh "Battery capacity: ${batteryCapacity}% - Status: ${batteryStatus}" "DEBUG"
 
 # get signal quality
 rssi=$(./scripts/getrssi.sh)
@@ -72,7 +62,7 @@ rssi=$(./scripts/getrssi.sh)
 curl "${trmnl_apiurl}/display" -L \
     -H "ID: $trmnl_id" \
     -H "Access-Token: $trmnl_token" \
-    -H "Battery-Voltage: $trmnl_fake_voltage" \
+    -H "Percent-Charged: $batteryCapacity" \
     -H "RSSI: $rssi" \
     -H "FW-Version: ${trmnl_firmware_version}" \
     -o /tmp/trmnl.json >>/tmp/debug.log 2>&1

--- a/src/TRMNL/trmnlloop.sh
+++ b/src/TRMNL/trmnlloop.sh
@@ -7,6 +7,8 @@ FAILURE_COUNT_FILE=/tmp/trmnl_failures
 FIRST_RETRY_DELAY=60
 DEFAULT_REFRESH=900
 MAX_SUSPEND_ATTEMPTS=5
+# set by trmnl.sh, which owns the watcher that writes it
+STOP_FLAG=${TRMNL_STOP_FLAG:-/tmp/trmnl_stop}
 
 # Echo $1 if it is a positive integer, $2 otherwise
 SaneSeconds() {
@@ -99,6 +101,13 @@ SuspendFor() {
     deadline=$(($(date +%s) + total_seconds))
     attempt=0
     while :; do
+        # Serving out the sleep must not outrank the stop button, or a press
+        # would not be noticed until the whole refresh had been slept away
+        if [ -e "$STOP_FLAG" ]; then
+            ./scripts/log.sh "Stop requested, ending the sleep early" "DEBUG"
+            break
+        fi
+
         remaining=$((deadline - $(date +%s)))
         # close enough, another suspend would cost more than it saves
         [ $remaining -le 10 ] && break
@@ -108,9 +117,16 @@ SuspendFor() {
             ./scripts/log.sh "still ${remaining}s short after ${MAX_SUSPEND_ATTEMPTS} suspends, carrying on" "WARN"
             break
         fi
-        [ $attempt -gt 1 ] && ./scripts/log.sh "woken ${remaining}s early, suspending again" "WARN"
 
         SuspendOnce $remaining
+
+        # Coming back early is usually someone pressing power to look at the
+        # screen, so stay up long enough for them to press home, otherwise we
+        # would drop back to sleep before the button could be used at all
+        if [ $((deadline - $(date +%s))) -gt 10 ]; then
+            ./scripts/log.sh "woken early, staying up briefly in case you want to stop" "WARN"
+            sleep 5s
+        fi
     done
 }
 


### PR DESCRIPTION
## Wi-Fi plumbing

- Detect the wireless interface from `/proc/net/wireless` instead of hardcoding `eth0`. When `INTERFACE` isn't inherited from Nickel it fell back to `eth0`, which is `wlan0` on some devices — so every wifi script operated on a device that doesn't exist, the radio was never powered down, and the loop spun instead of sleeping.
- Fix three broken relative paths: `luajit` in the fallback power toggle, `./scripts/disable-wifi.sh` in `restore-wifi-async.sh`, and `./scripts/release-ip.sh` in `obtain-ip.sh`. All silently did nothing.
- Wait for an interface to actually get an IP instead of sleeping a fixed 8s, so the radio powers down sooner on a healthy connection. `ConnectedGracePeriod` now extends that budget rather than being a blind delay.
- Parse `iwconfig` output with either `:` or `=` before the value. The separator is per-field and driver-dependent (`IW_QUAL_*_UPDATED`), not a version difference.

## Device reporting

- Send `Percent-Charged` and `Battery-Charging` instead of faking a voltage from the percentage for the server to convert back. TRMNL documents `Percent-Charged` as preferred, and the charging state was already read from sysfs and thrown away.
- Export `rssi` so the log endpoint reports it too — it was only ever set in `trmnlloop.sh`, so `logToServer.sh` sent an empty header.

## Talking to the server

- Add `--fail`, `--connect-timeout` and `--max-time` to every curl. Without `--fail` an HTTP error was parsed as a payload and only failed a round-trip later; without a time limit a stalled server held the radio on indefinitely.
- Append `/api` to `TrmnlApiUrl` when it's missing, behind a new `AppendApiPath` setting (default on). Leaving it off is a common BYOS mistake. Fixes #28.
- Send device logs as `{"logs":[{...}]}`, the shape the server actually reads. The old `{"log":["msg"]}` stored nothing while still answering `{"status":200}`, and log lines containing quotes produced invalid JSON. Body is now built with `jq`.
- Stop posting logs once the wifi is down — every line was still attempting a POST with no network, one burning the full 30s timeout.

## Sleep and wake

- Arm the RTC alarm before the fallback suspend. busybox `rtcwake` issues `RTC_AIE_OFF` on resume, so when the script decided rtcwake had failed and wrote `mem` itself, there was no wake timer at all and the device only stirred on an outside event. Relevant to #4, which is closed on the assumption this path works.
- Serve out the remaining time when a suspend returns early instead of carrying on, so a stray wakeup costs seconds rather than a whole wifi-and-fetch cycle. Bounded so constant wakeups can't trap it.

## Exiting

- Press the **home button** to stop the loop and return to the Kobo UI without the hold-power reboot. Fixes #18.
  - A small LuaJIT watcher holds the input device open for the whole run, since the kernel drops events for a device nobody has open and the device is suspended most of the time.
  - Filters on `KEY_HOME`: the power button shares the same node, so reacting to any key would stop the loop on every wake.
  - `restore-nickel.sh` restores the framebuffer bitdepth/rotation and CPU governor — all already recorded by `trmnl.sh` and previously unused — before starting Nickel the way KOReader does. Falls back to the reboot if that fails.
  - Devices with no readable home button log a warning and behave exactly as before.

## Diagnostics

- Timestamp every log line with its level, so sleep durations are readable off `debug.log`.
- Route `fbink`/`fbdepth` output to `debug.log` and record the display exit status and image size. They were the last commands writing to the console, and a failed draw was indistinguishable from a successful one.
- Document `LogToServer`, which was read by `trmnl.sh` but present in neither the readme nor `config.json`. Note that it's case-sensitive and silently sends nothing on an unrecognised value. Completes #6.

